### PR TITLE
Revert "added test for callrequester.create(from,to,applicationId), s…

### DIFF
--- a/persy-cs-sdk-test/api/call/CallsRequesterTest.cs
+++ b/persy-cs-sdk-test/api/call/CallsRequesterTest.cs
@@ -28,43 +28,6 @@ namespace persy_cs_sdk_test.api.call
         }
 
         [TestMethod]
-        public void MakeACallsRequestAppIdNoOptionsTest()     
-        {
-            try
-            {
-                CallsRequester callsRequester = new CallsRequester("AC736ca2078721a9a41fb47f07bf40d9e21cb304da", "8e3d1c1c519fc761856f8cc825bcfea94d8c58b5", "AC736ca2078721a9a41fb47f07bf40d9e21cb304da");
-
-                Type callsRequesterType = typeof(CallsRequester);
-                MethodInfo persyUrlMethodInfo = callsRequesterType.GetMethod("setPersyUrl", 
-                                                                             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, 
-                                                                             null, 
-                                                                             new Type[] { typeof(System.String) }, 
-                                                                             null);
-                persyUrlMethodInfo.Invoke(callsRequester, new Object[] { "http://MakeACallsRequestAppIdNoOptionsTest:3000" });
-
-                WebRequest.RegisterPrefix("http://MakeACallsRequestAppIdNoOptionsTest:3000", new TestWebRequestCreate());
-
-                TestWebRequestCreate.MockHttpWebRequestWithGivenResponseCode(HttpStatusCode.OK,
-                                                                             "{\"uri\" : \"/Accounts/AC736ca2078721a9a41fb47f07bf40d9e21cb304da/Calls/CA16ac1bcbd6f4895c89a798571e89e1e715892924\", \"revision\" : 1, \"dateCreated\" : \"Thu, 23 Jun 2016 17:30:06 GMT\", \"dateUpdated\" : \"Thu, 23 Jun 2016 17:30:06 GMT\", \"callId\" : \"CA16ac1bcbd6f4895c89a798571e89e1e715892924\", \"parentCallId\" : null, \"accountId\" : \"AC736ca2078721a9a41fb47f07bf40d9e21cb304da\", \"from\" : \"+12248806205\", \"to\" : \"+18475978014\", \"phoneNumberId\" : \"PN1311218371073288ff9c0434698753f98ea4228a\", \"status\" : \"queued\", \"startTime\" : null, \"endTime\" : null, \"duration\" : 0, \"direction\" : \"outboundAPI\", \"answeredBy\" : null, \"callerName\" : null, \"subresourceUris\" : {\"notifications\" : \"/Accounts/AC736ca2078721a9a41fb47f07bf40d9e21cb304da/Calls/CA16ac1bcbd6f4895c89a798571e89e1e715892924/Notifications\", \"recordings\" : \"/Accounts/AC736ca2078721a9a41fb47f07bf40d9e21cb304da/Calls/CA16ac1bcbd6f4895c89a798571e89e1e715892924/Recordings\"}}");
-
-                Call call = callsRequester.create("+18475978014", "+12248806205", "AC736ca2078721a9a41fb47f07bf40d9e21cb304da");
-
-                Assert.IsNotNull(call);
-                Assert.IsNotNull(call.getUri);
-                Assert.AreEqual(call.getUri, "/Accounts/AC736ca2078721a9a41fb47f07bf40d9e21cb304da/Calls/CA16ac1bcbd6f4895c89a798571e89e1e715892924");
-                Assert.AreEqual(call.getSubresourceUris.Count, 2);
-                Assert.AreEqual(call.getRevision, 1);
-                Assert.IsNotNull(call.getDateCreated);
-                Assert.IsNotNull(call.getDateUpdated);
-                Assert.AreEqual(call.getStatus, ECallStatus.Queued);
-            }
-            catch (PersyException pe)
-            {
-                Assert.Fail(pe.Message);
-            }
-        }
-
-        [TestMethod]
         public void MakeAInitialCallsRequestTest()     
         {
             try

--- a/persy-cs-sdk/api/call/CallsRequester.cs
+++ b/persy-cs-sdk/api/call/CallsRequester.cs
@@ -65,7 +65,7 @@ namespace com.persephony.api.call
             OutboundCall outboundCall = new OutboundCall(callOptions);
             outboundCall.setTo(to);
             outboundCall.setFrom(from);
-            outboundCall.setApplicationId(applicationId);
+            outboundCall.setCallConnectUrl(applicationId);
 
             string json = base.POST(this.path, outboundCall.toJson());
 


### PR DESCRIPTION
…o no call options passed. Also fixed a bug in the SDK's CallRequester class, in the create method that this test was created for. The method was setting the callControlUrl property of the OutboundCall boject with the applicaitonId parameter passed to the function; it should have been setting the applicationId property"

This reverts commit 32b9ab5b1057827c6bc15dc660fe0249789c765b.